### PR TITLE
bug: s/encodeURIComponent/encodeUriComponent/

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -69,7 +69,7 @@ ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
     // the minified tag bundle for this account:
     src:
       "https://c.lytics.io/api/tag/" +
-      encodeURIComponent(data.accountId) +
+      encodeUriComponent(data.accountId) +
       "/latest.min.js",
   };
 


### PR DESCRIPTION
Fixes a gratuitous capitalization difference between [`encodeURIComponent`, the normal and well-documented DOM global](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent), and the similarly-named [`encodeUriComponent` function of Sandboxed JavaScript](https://developers.google.com/tag-manager/templates/api#encodeuricomponent). 🤦 